### PR TITLE
upload-speed cron jobs

### DIFF
--- a/swarm-staging.yaml
+++ b/swarm-staging.yaml
@@ -24,5 +24,5 @@ swarm:
       enabled: true
       acmeEnabled: false
     annotations:
-      nginx.ingress.kubernetes.io/proxy-body-size: 50m
+      nginx.ingress.kubernetes.io/proxy-body-size: 120m
       nginx.ingress.kubernetes.io/ssl-redirect: "false"

--- a/upload-speed-100M.yaml
+++ b/upload-speed-100M.yaml
@@ -1,0 +1,6 @@
+uploadSpeed:
+  schedule: "*/5 * * * *"
+  config:
+    filesize: 100000
+    swarmReplicas: 1 
+    target: "swarm"

--- a/upload-speed-100M.yaml
+++ b/upload-speed-100M.yaml
@@ -1,4 +1,4 @@
-uploadSpeed:
+smoke:
   schedule: "*/5 * * * *"
   config:
     filesize: 100000

--- a/upload-speed-100M.yaml
+++ b/upload-speed-100M.yaml
@@ -4,3 +4,4 @@ smoke:
     filesize: 100000
     swarmReplicas: 1 
     target: "swarm"
+    operation: "upload_speed"

--- a/upload-speed-100M.yaml
+++ b/upload-speed-100M.yaml
@@ -1,7 +1,9 @@
 smoke:
   schedule: "*/5 * * * *"
   config:
-    filesize: 100000
+    name: "upload-speed-1OOM"
     swarmReplicas: 1 
     target: "swarm"
     operation: "upload_speed"
+    extraFlags:
+      - --filesize=100000

--- a/upload-speed-10M.yaml
+++ b/upload-speed-10M.yaml
@@ -1,0 +1,6 @@
+uploadSpeed:
+  schedule: "*/5 * * * *"
+  config:
+    filesize: 10000 
+    swarmReplicas: 1 
+    target: "swarm"

--- a/upload-speed-10M.yaml
+++ b/upload-speed-10M.yaml
@@ -4,3 +4,4 @@ smoke:
     filesize: 10000 
     swarmReplicas: 1 
     target: "swarm"
+    operation: "upload_speed"

--- a/upload-speed-10M.yaml
+++ b/upload-speed-10M.yaml
@@ -1,7 +1,9 @@
 smoke:
   schedule: "*/5 * * * *"
   config:
-    filesize: 10000 
+    name: "upload-speed-10M"
     swarmReplicas: 1 
     target: "swarm"
     operation: "upload_speed"
+    extraFlags:
+      - --filesize=10000

--- a/upload-speed-10M.yaml
+++ b/upload-speed-10M.yaml
@@ -1,4 +1,4 @@
-uploadSpeed:
+smoke:
   schedule: "*/5 * * * *"
   config:
     filesize: 10000 


### PR DESCRIPTION
This PR addresses issue https://github.com/ethersphere/go-ethereum/issues/1091

It adds a cron job to create a period upload speed test