### PR TITLE
Split version from other values

### DIFF
--- a/staging.yaml
+++ b/staging.yaml
@@ -23,7 +23,9 @@ apps:
     chart: "ethersphere/swarm"
     version: "0.0.1"
     description: "Swarm staging cluster"
-    valuesFile: "staging/swarm.yaml"
+    valuesFiles:
+      - "staging/swarm.yaml"
+      - "staging/swarm-version.yaml"
     wait: true
     timeout: 600
   smoke-50:

--- a/staging/swarm-version.yaml
+++ b/staging/swarm-version.yaml
@@ -1,0 +1,4 @@
+swarm:
+  image:
+    repository: ethdevops/swarm
+    tag: edge

--- a/staging/swarm.yaml
+++ b/staging/swarm.yaml
@@ -4,9 +4,6 @@ swarm:
   profilingEnabled: false
   terminationGracePeriodSeconds: 5
   podManagementPolicy: Parallel
-  image:
-    repository: ethdevops/swarm
-    tag: edge
   replicaCount: 21
   config:
     ens_api: http://mainnet-geth-geth.geth:8545


### PR DESCRIPTION
separate the version that should be deployed to a separate file, so that it can be easier integrated for continuous delivery