### PR TITLE
staging: enable WebSocket APIs

### DIFF
--- a/staging/swarm.yaml
+++ b/staging/swarm.yaml
@@ -12,6 +12,9 @@ swarm:
     maxpeers: 25
     bzznetworkid: 3
     storesize: "5000000" # 5000000 * 4KB = 20GB
+    extraFlags:
+      - --ws
+      - --wsorigins=localhost
   secrets:
     password: qwerty
   ingress:

--- a/staging/swarm.yaml
+++ b/staging/swarm.yaml
@@ -14,7 +14,9 @@ swarm:
     storesize: "5000000" # 5000000 * 4KB = 20GB
     extraFlags:
       - --ws
+      - --wsaddr=0.0.0.0
       - --wsorigins=localhost
+      - --wsapi=admin,net,debug
   secrets:
     password: qwerty
   ingress:


### PR DESCRIPTION
I think it'd be nice to expose the WS APIs, so that we can interact with the nodes in staging over WebSocket as well.

For example:
```
# returns admin.peers
kubectl exec -n staging -ti swarm-staging-0 -- /geth --exec="admin.peers" attach /root/.ethereum/bzzd.ipc

# returns admin.peers in JSON, which is easier to parse and to extract specific fields from
echo '{"jsonrpc":"2.0","method":"admin_peers","id":1}' | websocat ws://localhost:8546 --origin localhost | jq ".[]" | tail -n+3 | jq ".[] | .enode"

# assumes we have port forwarded the WS port to localhost
kubectl port-forward -n staging pods/swarm-staging-0 8546:8546
```