### PR TITLE
swarm-private: persist bootnode state

### DIFF
--- a/staging/private-swarm.yaml
+++ b/staging/private-swarm.yaml
@@ -1,3 +1,18 @@
+bootnode:
+  persistence:
+    enabled: true
+    storageClass: "gp2"
+    accessMode: ReadWriteOnce
+    size: 1Gi
+  resources:
+    requests:
+      memory: 512Mi
+      cpu: 0.1
+    limits:
+      memory: 1024Mi
+      cpu: 0.3
+
+
 swarm:
   metricsEnabled: true
   tracingEnabled: true


### PR DESCRIPTION
and set default limits