### PR TITLE
travis: fix deploy script

### DIFF
--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -5,6 +5,7 @@ HELMSMAN="helmsman -no-banner -no-ns -no-fancy"
 # Store version of current deployed statefulsets
 kubectl config use-context staging
 PUBLIC_OLD_VERSION=$(kubectl -n staging get sts swarm-public -o jsonpath="{.metadata.resourceVersion}")
+kubectl config use-context staging-private
 PRIVATE_OLD_VERSION=$(kubectl -n staging-private get sts swarm-private -o jsonpath="{.metadata.resourceVersion}")
 
 # Perform updates
@@ -17,12 +18,15 @@ done
 # Check if the statefulsets were updated
 kubectl config use-context staging
 PUBLIC_NEW_VERSION=$(kubectl -n staging get sts swarm-public -o jsonpath="{.metadata.resourceVersion}")
+kubectl config use-context staging-private
 PRIVATE_NEW_VERSION=$(kubectl -n staging-private get sts swarm-private -o jsonpath="{.metadata.resourceVersion}")
 
 if [ "$PUBLIC_OLD_VERSION" != "$PUBLIC_NEW_VERSION" ]; then
+  kubectl config use-context staging
   kubectl -n staging delete pods -l release=swarm-public,app=swarm,component=swarm
 fi
 
 if [ "$PRIVATE_OLD_VERSION" != "$PRIVATE_NEW_VERSION" ]; then
+  kubectl config use-context staging-private
   kubectl -n staging-private delete pods -l release=swarm-private,app=swarm-private,component=swarm
 fi


### PR DESCRIPTION
Change to the correct contexts for the different namespaces. 

Note: This will be deprecated once we add a post-update hook on the helm charts so that these can perform the deletion of pods.